### PR TITLE
Add basic README for package publishing

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,38 @@
+# buildkite-sdk
+
+[![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
+
+A Ruby SDK for [Buildkite](https://buildkite.com)! 🪁
+
+## Usage
+
+Install the package:
+
+```bash
+go get github.com/buildkite/buildkite-sdk/sdk/go
+```
+
+Use it in your program:
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/buildkite/buildkite-sdk/sdk/go/sdk/buildkite"
+)
+
+func main() {
+	pipeline := buildkite.Pipeline{}
+	command := "echo 'Hello, world!"
+
+	pipeline.AddCommandStep(buildkite.CommandStep{
+		Command: &buildkite.CommandUnion{
+			String: &command,
+		},
+	})
+
+	fmt.Println(pipeline.ToJSON())
+	fmt.Println(pipeline.ToYAML())
+}
+```

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
 
-A Ruby SDK for [Buildkite](https://buildkite.com)! 🪁
+A Go SDK for [Buildkite](https://buildkite.com)! 🪁
 
 ## Usage
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
 
-A Ruby SDK for [Buildkite](https://buildkite.com)! 🪁
+A Python SDK for [Buildkite](https://buildkite.com)! 🪁
 
 ## Usage
 
@@ -22,3 +22,4 @@ pipeline.add_step({"command": "echo 'Hello, world!'"})
 
 print(pipeline.to_json())
 print(pipeline.to_yaml())
+```

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,3 +1,24 @@
 # buildkite-sdk
 
-Project description here.
+[![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
+
+A Ruby SDK for [Buildkite](https://buildkite.com)! 🪁
+
+## Usage
+
+Install the package:
+
+```bash
+uv add buildkite-sdk
+```
+
+Use it in your program:
+
+```python
+from buildkite_sdk import Pipeline
+
+pipeline = Pipeline()
+pipeline.add_step({"command": "echo 'Hello, world!'"})
+
+print(pipeline.to_json())
+print(pipeline.to_yaml())

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -1,31 +1,29 @@
-# Buildkite
+# buildkite-sdk
 
-TODO: Delete this and the text below, and describe your gem
+[![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/buildkite`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-## Installation
-
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
-
-Install the gem and add to the application's Gemfile by executing:
-
-    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
-
-If bundler is not being used to manage dependencies, install the gem by executing:
-
-    $ gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+A Ruby SDK for [Buildkite](https://buildkite.com)! 🪁
 
 ## Usage
 
-TODO: Write usage instructions here
+Install the package:
 
-## Development
+```bash
+gem install buildkite-sdk
+```
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Use it in your program:
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+```ruby
+require "buildkite"
 
-## Contributing
+pipeline = Buildkite::Pipeline.new
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/buildkite.
+pipeline.add_step(
+  label: "some-label",
+  command: "echo 'Hello, World!'"
+)
+
+puts pipeline.to_json
+puts pipeline.to_yaml
+```

--- a/sdk/ruby/buildkite.gemspec
+++ b/sdk/ruby/buildkite.gemspec
@@ -3,11 +3,11 @@ require_relative "lib/buildkite/version"
 Gem::Specification.new do |spec|
   spec.name = "buildkite-sdk"
   spec.version = Buildkite::VERSION
-  spec.authors = ["Christian Nunciato"]
-  spec.email = ["chris.nunciato@buildkite.com"]
+  spec.authors = ["Buildkite"]
+  spec.email = ["support@buildkite.com"]
 
   spec.summary = "A Ruby SDK for Buildkite!"
-  spec.description = "A Ruby SDK for Buildkite!"
+  spec.description = File.read("README.md")
   spec.homepage = "https://buildkite.com"
   spec.required_ruby_version = ">= 3.0.0"
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,11 +1,28 @@
 # buildkite-sdk
 
-This library was generated with [Nx](https://nx.dev).
+[![Build status](https://badge.buildkite.com/a95a3beece2339d1783a0a819f4ceb323c1eb12fb9662be274.svg?branch=main)](https://buildkite.com/buildkite/pipeline-sdk)
 
-## Building
+A TypeScript SDK for [Buildkite](https://buildkite.com)! 🪁
 
-Run `nx build buildkite-sdk` to build the library.
+## Usage
 
-## Running unit tests
+Install the package:
 
-Run `nx test buildkite-sdk` to execute the unit tests via [Jest](https://jestjs.io).
+```bash
+npm install @buildkite/buildkite-sdk
+```
+
+Use it in your program:
+
+```javascript
+const { Pipeline } = require("@buildkite/buildkite-sdk");
+
+const pipeline = new Pipeline();
+
+pipeline.addStep({
+    command: "echo 'Hello, world!'",
+});
+
+console.log(pipeline.toJSON());
+console.log(pipeline.toYAML());
+```


### PR DESCRIPTION
This PR adds in some basic READMEs so that the pages generated on the package manager websites have a bit more info.

Feel free to make changes as you see fit, I am just after having the package pages have more relevant info before we cut our next release.