### PR TITLE
Clean up TS command step exports for better docs

### DIFF
--- a/sdk/typescript/src/commandStep.ts
+++ b/sdk/typescript/src/commandStep.ts
@@ -40,11 +40,11 @@ interface CommandStepOptionalAttributes {
     timeout_in_minutes?: number;
 }
 
-interface SingleCommandStep extends CommandStepOptionalAttributes {
+export interface SingleCommandStep extends CommandStepOptionalAttributes {
     command: string
 }
 
-interface MultipleCommandStep extends CommandStepOptionalAttributes {
+export interface MultipleCommandStep extends CommandStepOptionalAttributes {
     commands: string[]
 }
 

--- a/sdk/typescript/src/sdk.ts
+++ b/sdk/typescript/src/sdk.ts
@@ -1,14 +1,14 @@
 import * as yaml from "yaml";
 import { PipelineNotify, NotifyEnum } from './types'
 import { BlockStep } from './blockStep'
-import { CommandStep } from './commandStep'
+import { CommandStep, SingleCommandStep, MultipleCommandStep } from './commandStep'
 import { GroupStep } from './groupStep'
 import { InputStep } from './inputStep'
 import { TriggerStep } from './triggerStep'
 import { WaitStep } from './waitStep'
 export { EnvironmentVariable } from "./environment";
 
-export type { BlockStep, CommandStep, GroupStep, InputStep, TriggerStep, WaitStep  };
+export type { BlockStep, CommandStep, GroupStep, InputStep, TriggerStep, WaitStep, SingleCommandStep, MultipleCommandStep  };
 
 export type PipelineStep =
     | CommandStep


### PR DESCRIPTION
This PR adds some exports for the command step types so they are present in the docs.