### PR TITLE
Use version of license from original implementation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,4 @@
-Copyright (c) 2024 Buildkite Pty Ltd
-
-MIT License
+Copyright 2024 Buildkite Pty Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
This PR fixes up the license text so that hopefully the go docs will detect the license. This is the same text @cnunciato used in his personal publishing of the package where the docs works 🤞 