### PR TITLE
Align `command` and `commands` with the schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13927,7 +13927,7 @@
         },
         "sdk/typescript": {
             "name": "@buildkite/buildkite-sdk",
-            "version": "0.2.0",
+            "version": "0.2.3",
             "dependencies": {
                 "tslib": "^2.3.0",
                 "yaml": "^2.6.1"

--- a/sdk/go/sdk/buildkite/command_step.go
+++ b/sdk/go/sdk/buildkite/command_step.go
@@ -9,6 +9,7 @@ type CommandStep struct {
 	Branches               []string
 	Cache                  Cache
 	CancelOnBuildFailing   *bool
+	Command                *string
 	Commands               []string
 	Concurrency            *int64
 	ConcurrencyGroup       *string
@@ -40,10 +41,6 @@ func (step CommandStep) toPipelineStep() *PipelineStep {
 	}
 
 	commandStep := &PipelineStep{
-		Commands: &schema.CommandUnion{
-			StringArray: step.Commands,
-		},
-
 		ArtifactPaths:     step.ArtifactPaths,
 		Concurrency:       step.Concurrency,
 		ConcurrencyGroup:  step.ConcurrencyGroup,
@@ -59,6 +56,18 @@ func (step CommandStep) toPipelineStep() *PipelineStep {
 		Parallelism:       step.Parallelism,
 		Priority:          step.Priority,
 		TimeoutInMinutes:  step.TimeoutInMinutes,
+	}
+
+	if step.Commands != nil {
+		commandStep.Commands = &schema.CommandUnion{
+			StringArray: step.Commands,
+		}
+	}
+
+	if step.Command != nil {
+		commandStep.Command = &schema.CommandUnion{
+			String: step.Command,
+		}
 	}
 
 	if step.Agents != nil {

--- a/sdk/go/sdk/buildkite/command_step_test.go
+++ b/sdk/go/sdk/buildkite/command_step_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCommandStep(t *testing.T) {
-	t.Run("should create a simple command step", func(t *testing.T) {
+	t.Run("should create a commands step", func(t *testing.T) {
 		pipeline := NewPipeline()
 		pipeline.AddStep(CommandStep{
 			Commands: []string{
@@ -24,6 +24,26 @@ func TestCommandStep(t *testing.T) {
             "commands": [
                 "command"
             ]
+        }
+    ]
+}`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("should create a simple command step", func(t *testing.T) {
+		pipeline := NewPipeline()
+		cmd := "command"
+		pipeline.AddStep(CommandStep{
+			Command: &cmd,
+		})
+
+		result, err := pipeline.ToJSON()
+		assert.NoError(t, err)
+
+		expected := `{
+    "steps": [
+        {
+            "command": "command"
         }
     ]
 }`

--- a/sdk/python/src/buildkite_sdk/command_step.py
+++ b/sdk/python/src/buildkite_sdk/command_step.py
@@ -12,9 +12,9 @@ from buildkite_sdk.types import (
 )
 from buildkite_sdk.schema import CommandStep as _command_step
 
-
 class CommandStepArgs(TypedDict, total=False):
-    commands: Union[List[str], str]
+    commands: Optional[Union[List[str], str]]
+    command: Optional[Union[List[str], str]]
     agents: Optional[Union[Dict[str, Any], List[str]]]
     allow_dependency_failure: Optional[bool]
     artifact_paths: Optional[Union[List[str], str]]
@@ -45,7 +45,8 @@ class CommandStepArgs(TypedDict, total=False):
 
 
 def CommandStep(
-    commands: Union[List[str], str],
+    commands: Optional[Union[List[str], str]],
+    command: Optional[Union[List[str], str]],
     agents: Optional[Union[Dict[str, Any], List[str]]] = None,
     allow_dependency_failure: Optional[bool] = None,
     artifact_paths: Optional[Union[List[str], str]] = None,
@@ -81,6 +82,7 @@ def CommandStep(
         branches=branches,
         cache=cache,
         cancel_on_build_failing=cancel_on_build_failing,
+        command=command,
         commands=commands,
         concurrency=concurrency,
         concurrency_group=concurrency_group,

--- a/sdk/python/src/buildkite_sdk/command_step.py
+++ b/sdk/python/src/buildkite_sdk/command_step.py
@@ -45,8 +45,8 @@ class CommandStepArgs(TypedDict, total=False):
 
 
 def CommandStep(
-    commands: Optional[Union[List[str], str]],
-    command: Optional[Union[List[str], str]],
+    commands: Optional[Union[List[str], str]] = None,
+    command: Optional[Union[List[str], str]] = None,
     agents: Optional[Union[Dict[str, Any], List[str]]] = None,
     allow_dependency_failure: Optional[bool] = None,
     artifact_paths: Optional[Union[List[str], str]] = None,
@@ -106,5 +106,4 @@ def CommandStep(
         soft_fail=soft_fail,
         timeout_in_minutes=timeout_in_minutes,
         type=None,
-        command=None,
     )

--- a/sdk/python/tests/test_command_step.py
+++ b/sdk/python/tests/test_command_step.py
@@ -1,13 +1,22 @@
 from buildkite_sdk import Pipeline, CommandStep
 import json
 
+def test_command_step_multiple():
+    pipeline = Pipeline()
+    pipeline.add_step(CommandStep(
+        commands=["echo 'Hello, world!'"]
+    ))
+
+    expected = {"steps": [{"commands": ["echo 'Hello, world!'"]}]}
+    assert pipeline.to_json() == json.dumps(expected, indent="    ")
+
 def test_command_step_simple():
     pipeline = Pipeline()
     pipeline.add_step(CommandStep(
-        commands="echo 'Hello, world!'"
+        command="echo 'Hello, world!'"
     ))
 
-    expected = {"steps": [{"commands": "echo 'Hello, world!'"}]}
+    expected = {"steps": [{"command": "echo 'Hello, world!'"}]}
     assert pipeline.to_json() == json.dumps(expected, indent="    ")
 
 def test_command_step_typed_dict():

--- a/sdk/typescript/src/commandStep.ts
+++ b/sdk/typescript/src/commandStep.ts
@@ -10,13 +10,15 @@ import {
     SoftFail,
 } from './types'
 
-interface CommandStepOptionalAttributes {
+export interface CommandStep {
     agents?: string[] | { [key: string]: any };
     allow_dependency_failure?: boolean;
     artifact_paths?: string[] | string;
     branches?: string[] | string;
     cache?: string | string[] | CacheObject;
     cancel_on_build_failing?: boolean;
+    command?: string | string[];
+    commands?: string | string[];
     concurrency?: number;
     concurrency_group?: string;
     concurrency_method?: ConcurrencyMethod;
@@ -39,13 +41,3 @@ interface CommandStepOptionalAttributes {
     soft_fail?: SoftFail[] | boolean;
     timeout_in_minutes?: number;
 }
-
-export interface SingleCommandStep extends CommandStepOptionalAttributes {
-    command: string
-}
-
-export interface MultipleCommandStep extends CommandStepOptionalAttributes {
-    commands: string[]
-}
-
-export type CommandStep = SingleCommandStep | MultipleCommandStep

--- a/sdk/typescript/src/sdk.ts
+++ b/sdk/typescript/src/sdk.ts
@@ -1,14 +1,14 @@
 import * as yaml from "yaml";
 import { PipelineNotify, NotifyEnum } from './types'
 import { BlockStep } from './blockStep'
-import { CommandStep, SingleCommandStep, MultipleCommandStep } from './commandStep'
+import { CommandStep } from './commandStep'
 import { GroupStep } from './groupStep'
 import { InputStep } from './inputStep'
 import { TriggerStep } from './triggerStep'
 import { WaitStep } from './waitStep'
 export { EnvironmentVariable } from "./environment";
 
-export type { BlockStep, CommandStep, GroupStep, InputStep, TriggerStep, WaitStep, SingleCommandStep, MultipleCommandStep  };
+export type { BlockStep, CommandStep, GroupStep, InputStep, TriggerStep, WaitStep };
 
 export type PipelineStep =
     | CommandStep


### PR DESCRIPTION
This PR brings the behavior of the `command` and `commands` arguments in line with the schema. 

Fixes: https://github.com/buildkite/buildkite-sdk/issues/61
Fixes: https://github.com/buildkite/buildkite-sdk/issues/62