### PR TITLE
Remove ToYAML for the go sdk

### DIFF
--- a/apps/go/main.go
+++ b/apps/go/main.go
@@ -37,20 +37,4 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to write to file: %v", err)
 	}
-
-	yaml, err := pipeline.ToYAML()
-	if err != nil {
-		log.Fatalf("Failed to serialize JSON: %v", err)
-	}
-
-	yamlFile, err := os.Create("../../out/apps/go/pipeline.yaml")
-	if err != nil {
-		log.Fatalf("Failed to create file: %v", err)
-	}
-	defer yamlFile.Close()
-
-	_, err = yamlFile.WriteString(yaml)
-	if err != nil {
-		log.Fatalf("Failed to write to file: %v", err)
-	}
 }

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -33,6 +33,5 @@ func main() {
 	})
 
 	fmt.Println(pipeline.ToJSON())
-	fmt.Println(pipeline.ToYAML())
 }
 ```

--- a/sdk/go/sdk/buildkite/sdk.go
+++ b/sdk/go/sdk/buildkite/sdk.go
@@ -2,8 +2,6 @@ package buildkite
 
 import (
 	"encoding/json"
-
-	"gopkg.in/yaml.v3"
 )
 
 func NewPipeline() *Pipeline {
@@ -47,14 +45,6 @@ func (p *Pipeline) AddNotify(notify *PipelineNotify) {
 
 func (p *Pipeline) ToJSON() (string, error) {
 	data, err := json.MarshalIndent(p, "", "    ")
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-func (p *Pipeline) ToYAML() (string, error) {
-	data, err := yaml.Marshal(p)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR removes the `toYAML` method in the Go SDK. The way quick-type generated the Go types looks like it will be a less than trivial thing to get YAML to work correctly. So this PR removes the method while we work out the best way to handle generating/updating the types.

Fixes: https://github.com/buildkite/buildkite-sdk/issues/73