### PR TITLE
Convert to JSON and then YAML in go

### DIFF
--- a/apps/go/go.mod
+++ b/apps/go/go.mod
@@ -4,6 +4,6 @@ go 1.23.2
 
 require github.com/buildkite/buildkite-sdk/sdk/go v0.0.1
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require github.com/itchyny/json2yaml v0.1.4 // indirect
 
 replace github.com/buildkite/buildkite-sdk/sdk/go => ../../sdk/go

--- a/apps/go/go.sum
+++ b/apps/go/go.sum
@@ -1,10 +1,10 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/itchyny/json2yaml v0.1.4 h1:/pErVOXGG5iTyXHi/QKR4y3uzhLjGTEmmJIy97YT+k8=
+github.com/itchyny/json2yaml v0.1.4/go.mod h1:6iudhBZdarpjLFRNj+clWLAkGft+9uCcjAZYXUH9eGI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,11 +3,12 @@ module github.com/buildkite/buildkite-sdk/sdk/go
 go 1.23.2
 
 require (
+	github.com/itchyny/json2yaml v0.1.4
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/itchyny/json2yaml v0.1.4 h1:/pErVOXGG5iTyXHi/QKR4y3uzhLjGTEmmJIy97YT+k8=
+github.com/itchyny/json2yaml v0.1.4/go.mod h1:6iudhBZdarpjLFRNj+clWLAkGft+9uCcjAZYXUH9eGI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/sdk/go/sdk/buildkite/sdk.go
+++ b/sdk/go/sdk/buildkite/sdk.go
@@ -2,8 +2,10 @@ package buildkite
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/itchyny/json2yaml"
 )
 
 func NewPipeline() *Pipeline {
@@ -54,9 +56,16 @@ func (p *Pipeline) ToJSON() (string, error) {
 }
 
 func (p *Pipeline) ToYAML() (string, error) {
-	data, err := yaml.Marshal(p)
+	data, err := p.ToJSON()
 	if err != nil {
 		return "", err
 	}
-	return string(data), nil
+
+	var output strings.Builder
+	input := strings.NewReader(data)
+	if err := json2yaml.Convert(&output, input); err != nil {
+		return "", fmt.Errorf("converting JSON to YAML: %v", err)
+	}
+
+	return output.String(), nil
 }


### PR DESCRIPTION
This PR fixes up the YAML output for the Go SDK by first marshaling to JSON and then converting to YAML, avoiding having to support marshal functions for YAML on all the union types.

Fixes: https://github.com/buildkite/buildkite-sdk/issues/73