### PR TITLE
Fix isinstance call to be python 3.9 compatible.

### DIFF
--- a/sdk/python/src/buildkite_sdk/sdk.py
+++ b/sdk/python/src/buildkite_sdk/sdk.py
@@ -68,14 +68,14 @@ class Pipeline:
         step = props
         if isinstance(
             props,
-            Union[
+            (
                 _block_step,
                 _command_step,
                 _group_step,
                 _input_step,
                 _trigger_step,
                 _wait_step,
-            ],
+            ),
         ):
             step = props.to_dict()
 


### PR DESCRIPTION
Fix for https://github.com/buildkite/buildkite-sdk/issues/96