### PR TITLE
Fix nil pointer in go env variables

### DIFF
--- a/internal/gen/types/value.go
+++ b/internal/gen/types/value.go
@@ -45,9 +45,9 @@ func (p *Pipeline) AddAgent(key string, value any) {
 }
 
 func (p *Pipeline) AddEnvironmentVariable(key string, value any) {
-	env := *p.Env
-	if p.Env == nil {
-		env = map[string]interface{}{}
+	env := map[string]interface{}{}
+	if p.Env != nil {
+		env = *p.Env
 	}
 
 	env[key] = value

--- a/sdk/go/sdk/buildkite/pipeline.go
+++ b/sdk/go/sdk/buildkite/pipeline.go
@@ -50,9 +50,9 @@ func (p *Pipeline) AddAgent(key string, value any) {
 }
 
 func (p *Pipeline) AddEnvironmentVariable(key string, value any) {
-	env := *p.Env
-	if p.Env == nil {
-		env = map[string]interface{}{}
+	env := map[string]interface{}{}
+	if p.Env != nil {
+		env = *p.Env
 	}
 
 	env[key] = value

--- a/sdk/go/sdk_test/pipeline_test.go
+++ b/sdk/go/sdk_test/pipeline_test.go
@@ -1,0 +1,54 @@
+package sdk_test
+
+import (
+	"testing"
+
+	buildkite "github.com/buildkite/buildkite-sdk/sdk/go/sdk/buildkite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeline(t *testing.T) {
+	t.Run("AddAgent", func(t *testing.T) {
+		pipeline := buildkite.NewPipeline()
+		pipeline.AddAgent("foo", "bar")
+
+		result, err := pipeline.ToJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"agents":{"foo":"bar"}}`, result)
+	})
+
+	t.Run("AddEnvironmentVariable", func(t *testing.T) {
+		pipeline := buildkite.NewPipeline()
+		pipeline.AddEnvironmentVariable("FOO", "bar")
+
+		result, err := pipeline.ToJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"env":{"FOO":"bar"}}`, result)
+	})
+
+	t.Run("Notify", func(t *testing.T) {
+		pipeline := buildkite.NewPipeline()
+		pipeline.AddNotify(buildkite.BuildNotifyItem{
+			NotifyEmail: &buildkite.NotifyEmail{
+				Email: buildkite.Value("person@example.com"),
+			},
+		})
+
+		result, err := pipeline.ToJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"notify":[{"email":"person@example.com"}]}`, result)
+	})
+
+	t.Run("Steps", func(t *testing.T) {
+		pipeline := buildkite.NewPipeline()
+		pipeline.AddStep(buildkite.CommandStep{
+			Command: &buildkite.CommandStepCommand{
+				String: buildkite.Value("build.sh"),
+			},
+		})
+
+		result, err := pipeline.ToJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"steps":[{"command":"build.sh"}]}`, result)
+	})
+}


### PR DESCRIPTION
This PR fixes up a nil pointer in the `AddEnvironmentVariable` method for Go.