### PR TITLE
Add `MISE_NODE_VERIFY` env var

### DIFF
--- a/ci/src/pipeline.ts
+++ b/ci/src/pipeline.ts
@@ -134,7 +134,7 @@ function generateAppCommands(key: string, appTarget: string) {
 
     return [
         "mise trust mise.apps.toml",
-        `mise install -v ${language}@{{matrix}} --raw`,
+        `mise install ${language}@{{matrix}}`,
         appInstallCommand,
         `mise exec ${language}@{{matrix}} -- nx run ${appTarget}:run`,
     ];
@@ -203,6 +203,9 @@ languageTargets.forEach((target) => {
                 plugins: languagePlugins,
                 commands: generateAppCommands(target.key, target.appTarget),
                 matrix: target.versions,
+                env: {
+                    MISE_NODE_VERIFY: false,
+                },
             },
         ],
     });


### PR DESCRIPTION
The node 24 matrix job was failing due a gpg issue. A lot of googling and asking Claude later I couldn't find a good answer for why it was happening. There were some older issues suggesting updating `mise` but we are already install the latest version.

Anyway this env var gets the job to pass and unblocks CI. 