### PR TITLE
fix: use uv sync for Python SDK install to include dev dependencies

### DIFF
--- a/sdk/python/project.json
+++ b/sdk/python/project.json
@@ -19,7 +19,7 @@
         "install": {
             "executor": "nx:run-commands",
             "options": {
-                "commands": ["uv venv", "uv pip install -r pyproject.toml"],
+                "commands": ["uv sync --group dev"],
                 "cwd": "sdk/python",
                 "parallel": false
             }


### PR DESCRIPTION
- Change install from 'uv pip install -r pyproject.toml' to 'uv sync'
- uv sync understands dependency-groups and installs pytest from dev group
- uv run pytest now works correctly after proper sync