### PR TITLE
Update pipeline to use correct IAM role with session tags

### DIFF
--- a/ci/src/release.ts
+++ b/ci/src/release.ts
@@ -16,7 +16,8 @@ const plugins = [
   }},
   { "rubygems-oidc#v0.2.0": { role: "rg_oidc_akr_emf87k6zphtb7x7adyrk" } },
   { "aws-assume-role-with-web-identity#v1.0.0": {
-    "role-arn": "arn:aws:iam::597088016345:role/marketing-website-production-pipeline-role"
+    "role-arn": "arn:aws:iam::597088016345:role/pipeline-buildkite-buildkite-sdk",
+    "session-tags": ["organization_slug", "organization_id", "pipeline_slug"],
   }},
   { "aws-ssm#v1.0.0": {
     parameters: {


### PR DESCRIPTION
The IAM role `arn:aws:iam::597088016345:role/marketing-website-production-pipeline-role` is being deleted shortly. 

An IAM role is being updated to allow this usage: https://github.com/buildkite/bk-marketing/pull/1037  (must be merged first)

I followed the example available in the bk-marketing pipeline to set up the session tags with this `.ts` pipeline: https://github.com/buildkite/bk-marketing/blob/0ee2c809d7e6a419c2c6c42ab91130b3f5242bb7/.buildkite/updateRoadmap.ts#L9-L18 