### PR TITLE
fix: uses the mise GH token to avoid rate limits

### DIFF
--- a/ci/src/pipeline.ts
+++ b/ci/src/pipeline.ts
@@ -3,11 +3,14 @@ import * as fs from "fs";
 import toml from "toml";
 
 const pipeline = new Pipeline();
+pipeline.setSecrets(["MISE_GITHUB_TOKEN"]);
+
 const plugins = [
     {
         "docker#v5.11.0": {
             image: "buildkite-sdk-tools:latest",
             "propagate-environment": true,
+            environment: ["MISE_GITHUB_TOKEN"],
         },
     },
 ];


### PR DESCRIPTION
## Description

Python attestations are getting rate limited because we don't use the GH token.

## Changes

- uses the readonly GH token to ensure Python attestations don't cause rate limit hits
