### PR TITLE
feat: add Go conditional validation helpers

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -59,7 +59,7 @@ and `ValidateConditionals` walks a pipeline's step and notification conditions
 before serialization:
 
 ```go
-condition, err := buildkite.Condition(`step.label == "Deploy"`)
+condition, err := buildkite.Condition(`build.branch == "main"`)
 if err != nil {
 	log.Fatalf("Invalid condition: %v", err)
 }

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -19,6 +19,8 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/buildkite/buildkite-sdk/sdk/go/sdk/buildkite"
 )
 
@@ -27,9 +29,14 @@ func main() {
 
 	pipeline.AddStep(buildkite.CommandStep{
 		Command: &buildkite.CommandStepCommand{
-			String: buildkite.Value("echo 'Hello, world!"),
+			String: buildkite.Value("echo 'Hello, world!'"),
 		},
+		If: buildkite.MustCondition(`build.branch == "main"`),
 	})
+
+	if err := buildkite.ValidateConditionals(pipeline); err != nil {
+		log.Fatalf("Failed to validate conditionals: %v", err)
+	}
 
 	json, err := pipeline.ToJSON()
 	if err != nil {
@@ -44,5 +51,23 @@ func main() {
 	}
 
 	fmt.Println(yaml)
+}
+```
+
+`Condition` returns the same `*string` shape used by generated SDK `if` fields,
+and `ValidateConditionals` walks a pipeline's step and notification conditions
+before serialization:
+
+```go
+condition, err := buildkite.Condition(`step.label == "Deploy"`)
+if err != nil {
+	log.Fatalf("Invalid condition: %v", err)
+}
+
+step := buildkite.CommandStep{
+	Command: &buildkite.CommandStepCommand{
+		String: buildkite.Value("./deploy.sh"),
+	},
+	If: condition,
 }
 ```

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,7 +3,7 @@ module github.com/buildkite/buildkite-sdk/sdk/go
 go 1.25.4
 
 require (
-	github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4
+	github.com/buildkite/conditional v1.0.0
 	github.com/itchyny/json2yaml v0.1.5
 	github.com/stretchr/testify v1.11.1
 )

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,12 +3,14 @@ module github.com/buildkite/buildkite-sdk/sdk/go
 go 1.25.4
 
 require (
+	github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4
 	github.com/itchyny/json2yaml v0.1.5
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,5 +1,9 @@
+github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4 h1:thybbHUf8g90CXLwMiPIWdkJMpgZgU+yCIAujMYUgDE=
+github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4/go.mod h1:fKYF0ZlB/xhihV3uPvNiH4h9earFii9KC4Wxlx+406w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/itchyny/json2yaml v0.1.5 h1:wKaepxwivjcn2ssiLu7v4KrLKSIILWtwD/8L054tTdI=
 github.com/itchyny/json2yaml v0.1.5/go.mod h1:lBQ0JI7HugKRQy/c5/U3KRymvBNub/HTbSXHS9/4018=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,5 +1,5 @@
-github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4 h1:thybbHUf8g90CXLwMiPIWdkJMpgZgU+yCIAujMYUgDE=
-github.com/buildkite/conditional v0.0.0-20260606220753-f86646e5c8d4/go.mod h1:fKYF0ZlB/xhihV3uPvNiH4h9earFii9KC4Wxlx+406w=
+github.com/buildkite/conditional v1.0.0 h1:4ChSac86B7Bz2h7TtA4dvrsU5rpiRY2PoYGu48MK268=
+github.com/buildkite/conditional v1.0.0/go.mod h1:fKYF0ZlB/xhihV3uPvNiH4h9earFii9KC4Wxlx+406w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=

--- a/sdk/go/sdk/buildkite/conditionals.go
+++ b/sdk/go/sdk/buildkite/conditionals.go
@@ -7,17 +7,17 @@ import (
 	bkconditional "github.com/buildkite/conditional"
 )
 
-// Condition validates a step-aware Buildkite conditional and returns it in the
-// pointer form used by SDK `if` fields.
+// Condition validates a Buildkite step `if` expression and returns it in the
+// pointer form used by generated SDK `if` fields.
 func Condition(expression string) (*string, error) {
-	if err := validateConditional(expression, bkconditional.EntryPointBuildConditionWithStep); err != nil {
+	if err := validateConditional(expression, bkconditional.EntryPointBuildCondition); err != nil {
 		return nil, err
 	}
 
 	return Value(expression), nil
 }
 
-// MustCondition validates a step-aware Buildkite conditional and panics if it
+// MustCondition validates a Buildkite step `if` expression and panics if it
 // is invalid.
 func MustCondition(expression string) *string {
 	condition, err := Condition(expression)
@@ -76,26 +76,32 @@ func validatePipelineSteps(path string, steps PipelineSteps, errs *[]error) {
 		switch {
 		case step.BlockStep != nil:
 			validateBlockStep(stepPath, *step.BlockStep, errs)
-		case step.CommandStep != nil:
-			validateCommandStep(stepPath, *step.CommandStep, errs)
-		case step.GroupStep != nil:
-			validateGroupStep(stepPath, *step.GroupStep, errs)
-		case step.InputStep != nil:
-			validateInputStep(stepPath, *step.InputStep, errs)
 		case step.NestedBlockStep != nil:
 			validateNestedBlockStep(stepPath, *step.NestedBlockStep, errs)
-		case step.NestedCommandStep != nil:
-			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
+		case step.StringBlockStep != nil:
+			continue
+		case step.InputStep != nil:
+			validateInputStep(stepPath, *step.InputStep, errs)
 		case step.NestedInputStep != nil:
 			validateNestedInputStep(stepPath, *step.NestedInputStep, errs)
-		case step.NestedTriggerStep != nil:
-			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
-		case step.NestedWaitStep != nil:
-			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
-		case step.TriggerStep != nil:
-			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.StringInputStep != nil:
+			continue
+		case step.CommandStep != nil:
+			validateCommandStep(stepPath, *step.CommandStep, errs)
+		case step.NestedCommandStep != nil:
+			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
 		case step.WaitStep != nil:
 			validateWaitStep(stepPath, *step.WaitStep, errs)
+		case step.NestedWaitStep != nil:
+			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
+		case step.StringWaitStep != nil:
+			continue
+		case step.TriggerStep != nil:
+			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.NestedTriggerStep != nil:
+			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
+		case step.GroupStep != nil:
+			validateGroupStep(stepPath, *step.GroupStep, errs)
 		}
 	}
 }
@@ -106,41 +112,47 @@ func validateGroupSteps(path string, steps GroupSteps, errs *[]error) {
 		switch {
 		case step.BlockStep != nil:
 			validateBlockStep(stepPath, *step.BlockStep, errs)
-		case step.CommandStep != nil:
-			validateCommandStep(stepPath, *step.CommandStep, errs)
-		case step.InputStep != nil:
-			validateInputStep(stepPath, *step.InputStep, errs)
 		case step.NestedBlockStep != nil:
 			validateNestedBlockStep(stepPath, *step.NestedBlockStep, errs)
-		case step.NestedCommandStep != nil:
-			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
+		case step.StringBlockStep != nil:
+			continue
+		case step.InputStep != nil:
+			validateInputStep(stepPath, *step.InputStep, errs)
 		case step.NestedInputStep != nil:
 			validateNestedInputStep(stepPath, *step.NestedInputStep, errs)
-		case step.NestedTriggerStep != nil:
-			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
-		case step.NestedWaitStep != nil:
-			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
-		case step.TriggerStep != nil:
-			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.StringInputStep != nil:
+			continue
+		case step.CommandStep != nil:
+			validateCommandStep(stepPath, *step.CommandStep, errs)
+		case step.NestedCommandStep != nil:
+			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
 		case step.WaitStep != nil:
 			validateWaitStep(stepPath, *step.WaitStep, errs)
+		case step.NestedWaitStep != nil:
+			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
+		case step.StringWaitStep != nil:
+			continue
+		case step.TriggerStep != nil:
+			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.NestedTriggerStep != nil:
+			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
 		}
 	}
 }
 
 func validateBlockStep(path string, step BlockStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 }
 
 func validateCommandStep(path string, step CommandStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 	if step.Notify != nil {
 		validateCommandNotifications(path+".notify", *step.Notify, errs)
 	}
 }
 
 func validateGroupStep(path string, step GroupStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 	if step.Notify != nil {
 		validateBuildNotifications(path+".notify", *step.Notify, bkconditional.EntryPointStepNotification, errs)
 	}
@@ -150,15 +162,15 @@ func validateGroupStep(path string, step GroupStep, errs *[]error) {
 }
 
 func validateInputStep(path string, step InputStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 }
 
 func validateTriggerStep(path string, step TriggerStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 }
 
 func validateWaitStep(path string, step WaitStep, errs *[]error) {
-	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildCondition, errs)
 }
 
 func validateNestedBlockStep(path string, step NestedBlockStep, errs *[]error) {
@@ -204,18 +216,22 @@ func validateBuildNotifications(path string, notifications BuildNotify, entryPoi
 	for i, notification := range notifications {
 		notificationPath := fmt.Sprintf("%s[%d]", path, i)
 		switch {
-		case notification.NotifyBasecamp != nil:
-			appendConditionalError(notificationPath+".if", notification.NotifyBasecamp.If, entryPoint, errs)
+		case notification.NotifySimple != nil:
+			continue
 		case notification.NotifyEmail != nil:
 			appendConditionalError(notificationPath+".if", notification.NotifyEmail.If, entryPoint, errs)
-		case notification.NotifyGithubCommitStatus != nil:
-			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, entryPoint, errs)
-		case notification.NotifyPagerduty != nil:
-			appendConditionalError(notificationPath+".if", notification.NotifyPagerduty.If, entryPoint, errs)
+		case notification.NotifyBasecamp != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyBasecamp.If, entryPoint, errs)
 		case notification.NotifySlack != nil:
 			appendConditionalError(notificationPath+".if", notification.NotifySlack.If, entryPoint, errs)
 		case notification.NotifyWebhook != nil:
 			appendConditionalError(notificationPath+".if", notification.NotifyWebhook.If, entryPoint, errs)
+		case notification.NotifyPagerduty != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyPagerduty.If, entryPoint, errs)
+		case notification.NotifyGithubCommitStatus != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, entryPoint, errs)
+		case notification.NotifyGithubCheck != nil:
+			continue
 		}
 	}
 }
@@ -224,12 +240,16 @@ func validateCommandNotifications(path string, notifications CommandStepNotify, 
 	for i, notification := range notifications {
 		notificationPath := fmt.Sprintf("%s[%d]", path, i)
 		switch {
+		case notification.NotifySimple != nil:
+			continue
 		case notification.NotifyBasecamp != nil:
 			appendConditionalError(notificationPath+".if", notification.NotifyBasecamp.If, bkconditional.EntryPointStepNotification, errs)
-		case notification.NotifyGithubCommitStatus != nil:
-			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, bkconditional.EntryPointStepNotification, errs)
 		case notification.NotifySlack != nil:
 			appendConditionalError(notificationPath+".if", notification.NotifySlack.If, bkconditional.EntryPointStepNotification, errs)
+		case notification.NotifyGithubCommitStatus != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, bkconditional.EntryPointStepNotification, errs)
+		case notification.NotifyGithubCheck != nil:
+			continue
 		}
 	}
 }

--- a/sdk/go/sdk/buildkite/conditionals.go
+++ b/sdk/go/sdk/buildkite/conditionals.go
@@ -1,0 +1,235 @@
+package buildkite
+
+import (
+	"errors"
+	"fmt"
+
+	bkconditional "github.com/buildkite/conditional"
+)
+
+// Condition validates a step-aware Buildkite conditional and returns it in the
+// pointer form used by SDK `if` fields.
+func Condition(expression string) (*string, error) {
+	if err := validateConditional(expression, bkconditional.EntryPointBuildConditionWithStep); err != nil {
+		return nil, err
+	}
+
+	return Value(expression), nil
+}
+
+// MustCondition validates a step-aware Buildkite conditional and panics if it
+// is invalid.
+func MustCondition(expression string) *string {
+	condition, err := Condition(expression)
+	if err != nil {
+		panic(err)
+	}
+
+	return condition
+}
+
+// ValidateConditionals validates all `if` expressions reachable from the
+// pipeline's steps and notifications.
+func ValidateConditionals(p Pipeline) error {
+	var errs []error
+
+	if p.Notify != nil {
+		validateBuildNotifications("notify", *p.Notify, bkconditional.EntryPointBuildNotification, &errs)
+	}
+	if p.Steps != nil {
+		validatePipelineSteps("steps", *p.Steps, &errs)
+	}
+
+	return errors.Join(errs...)
+}
+
+type conditionalPathError struct {
+	Path string
+	Err  error
+}
+
+func (e *conditionalPathError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Path, e.Err)
+}
+
+func (e *conditionalPathError) Unwrap() error {
+	return e.Err
+}
+
+func validateConditional(expression string, entryPoint bkconditional.EntryPoint) error {
+	return bkconditional.Validate(expression, bkconditional.Context{EntryPoint: entryPoint})
+}
+
+func appendConditionalError(path string, expression *string, entryPoint bkconditional.EntryPoint, errs *[]error) {
+	if expression == nil {
+		return
+	}
+
+	if err := validateConditional(*expression, entryPoint); err != nil {
+		*errs = append(*errs, &conditionalPathError{Path: path, Err: err})
+	}
+}
+
+func validatePipelineSteps(path string, steps PipelineSteps, errs *[]error) {
+	for i, step := range steps {
+		stepPath := fmt.Sprintf("%s[%d]", path, i)
+		switch {
+		case step.BlockStep != nil:
+			validateBlockStep(stepPath, *step.BlockStep, errs)
+		case step.CommandStep != nil:
+			validateCommandStep(stepPath, *step.CommandStep, errs)
+		case step.GroupStep != nil:
+			validateGroupStep(stepPath, *step.GroupStep, errs)
+		case step.InputStep != nil:
+			validateInputStep(stepPath, *step.InputStep, errs)
+		case step.NestedBlockStep != nil:
+			validateNestedBlockStep(stepPath, *step.NestedBlockStep, errs)
+		case step.NestedCommandStep != nil:
+			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
+		case step.NestedInputStep != nil:
+			validateNestedInputStep(stepPath, *step.NestedInputStep, errs)
+		case step.NestedTriggerStep != nil:
+			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
+		case step.NestedWaitStep != nil:
+			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
+		case step.TriggerStep != nil:
+			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.WaitStep != nil:
+			validateWaitStep(stepPath, *step.WaitStep, errs)
+		}
+	}
+}
+
+func validateGroupSteps(path string, steps GroupSteps, errs *[]error) {
+	for i, step := range steps {
+		stepPath := fmt.Sprintf("%s[%d]", path, i)
+		switch {
+		case step.BlockStep != nil:
+			validateBlockStep(stepPath, *step.BlockStep, errs)
+		case step.CommandStep != nil:
+			validateCommandStep(stepPath, *step.CommandStep, errs)
+		case step.InputStep != nil:
+			validateInputStep(stepPath, *step.InputStep, errs)
+		case step.NestedBlockStep != nil:
+			validateNestedBlockStep(stepPath, *step.NestedBlockStep, errs)
+		case step.NestedCommandStep != nil:
+			validateNestedCommandStep(stepPath, *step.NestedCommandStep, errs)
+		case step.NestedInputStep != nil:
+			validateNestedInputStep(stepPath, *step.NestedInputStep, errs)
+		case step.NestedTriggerStep != nil:
+			validateNestedTriggerStep(stepPath, *step.NestedTriggerStep, errs)
+		case step.NestedWaitStep != nil:
+			validateNestedWaitStep(stepPath, *step.NestedWaitStep, errs)
+		case step.TriggerStep != nil:
+			validateTriggerStep(stepPath, *step.TriggerStep, errs)
+		case step.WaitStep != nil:
+			validateWaitStep(stepPath, *step.WaitStep, errs)
+		}
+	}
+}
+
+func validateBlockStep(path string, step BlockStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+}
+
+func validateCommandStep(path string, step CommandStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	if step.Notify != nil {
+		validateCommandNotifications(path+".notify", *step.Notify, errs)
+	}
+}
+
+func validateGroupStep(path string, step GroupStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+	if step.Notify != nil {
+		validateBuildNotifications(path+".notify", *step.Notify, bkconditional.EntryPointStepNotification, errs)
+	}
+	if step.Steps != nil {
+		validateGroupSteps(path+".steps", *step.Steps, errs)
+	}
+}
+
+func validateInputStep(path string, step InputStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+}
+
+func validateTriggerStep(path string, step TriggerStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+}
+
+func validateWaitStep(path string, step WaitStep, errs *[]error) {
+	appendConditionalError(path+".if", step.If, bkconditional.EntryPointBuildConditionWithStep, errs)
+}
+
+func validateNestedBlockStep(path string, step NestedBlockStep, errs *[]error) {
+	if step.Block != nil {
+		validateBlockStep(path+".block", *step.Block, errs)
+	}
+}
+
+func validateNestedCommandStep(path string, step NestedCommandStep, errs *[]error) {
+	if step.Command != nil {
+		validateCommandStep(path+".command", *step.Command, errs)
+	}
+	if step.Commands != nil {
+		validateCommandStep(path+".commands", *step.Commands, errs)
+	}
+	if step.Script != nil {
+		validateCommandStep(path+".script", *step.Script, errs)
+	}
+}
+
+func validateNestedInputStep(path string, step NestedInputStep, errs *[]error) {
+	if step.Input != nil {
+		validateInputStep(path+".input", *step.Input, errs)
+	}
+}
+
+func validateNestedTriggerStep(path string, step NestedTriggerStep, errs *[]error) {
+	if step.Trigger != nil {
+		validateTriggerStep(path+".trigger", *step.Trigger, errs)
+	}
+}
+
+func validateNestedWaitStep(path string, step NestedWaitStep, errs *[]error) {
+	if step.Wait != nil {
+		validateWaitStep(path+".wait", *step.Wait, errs)
+	}
+	if step.Waiter != nil {
+		validateWaitStep(path+".waiter", *step.Waiter, errs)
+	}
+}
+
+func validateBuildNotifications(path string, notifications BuildNotify, entryPoint bkconditional.EntryPoint, errs *[]error) {
+	for i, notification := range notifications {
+		notificationPath := fmt.Sprintf("%s[%d]", path, i)
+		switch {
+		case notification.NotifyBasecamp != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyBasecamp.If, entryPoint, errs)
+		case notification.NotifyEmail != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyEmail.If, entryPoint, errs)
+		case notification.NotifyGithubCommitStatus != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, entryPoint, errs)
+		case notification.NotifyPagerduty != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyPagerduty.If, entryPoint, errs)
+		case notification.NotifySlack != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifySlack.If, entryPoint, errs)
+		case notification.NotifyWebhook != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyWebhook.If, entryPoint, errs)
+		}
+	}
+}
+
+func validateCommandNotifications(path string, notifications CommandStepNotify, errs *[]error) {
+	for i, notification := range notifications {
+		notificationPath := fmt.Sprintf("%s[%d]", path, i)
+		switch {
+		case notification.NotifyBasecamp != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyBasecamp.If, bkconditional.EntryPointStepNotification, errs)
+		case notification.NotifyGithubCommitStatus != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifyGithubCommitStatus.If, bkconditional.EntryPointStepNotification, errs)
+		case notification.NotifySlack != nil:
+			appendConditionalError(notificationPath+".if", notification.NotifySlack.If, bkconditional.EntryPointStepNotification, errs)
+		}
+	}
+}

--- a/sdk/go/sdk_test/conditionals_test.go
+++ b/sdk/go/sdk_test/conditionals_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestCondition(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		condition, err := buildkite.Condition(`step.outcome == "passed"`)
+		condition, err := buildkite.Condition(`build.branch == "main"`)
 		require.NoError(t, err)
 		require.NotNil(t, condition)
-		assert.Equal(t, `step.outcome == "passed"`, *condition)
+		assert.Equal(t, `build.branch == "main"`, *condition)
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
@@ -21,6 +21,13 @@ func TestCondition(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, condition)
 		assert.ErrorContains(t, err, "no prefix parse function for EOF found")
+	})
+
+	t.Run("RejectsStepVariables", func(t *testing.T) {
+		condition, err := buildkite.Condition(`step.outcome == "passed"`)
+		require.Error(t, err)
+		assert.Nil(t, condition)
+		assert.ErrorContains(t, err, `step variables are not available for entry point "build_condition"`)
 	})
 }
 
@@ -52,7 +59,7 @@ func TestValidateConditionals(t *testing.T) {
 			Steps: &buildkite.PipelineSteps{
 				{
 					CommandStep: &buildkite.CommandStep{
-						If: buildkite.MustCondition(`step.outcome == "passed"`),
+						If: buildkite.MustCondition(`build.branch == "main"`),
 						Notify: &buildkite.CommandStepNotify{
 							{
 								NotifySlack: &buildkite.NotifySlack{
@@ -80,7 +87,7 @@ func TestValidateConditionals(t *testing.T) {
 							{
 								NestedTriggerStep: &buildkite.NestedTriggerStep{
 									Trigger: &buildkite.TriggerStep{
-										If: buildkite.MustCondition(`step.label == "Deploy"`),
+										If: buildkite.MustCondition(`build.tag == null`),
 									},
 								},
 							},
@@ -95,18 +102,42 @@ func TestValidateConditionals(t *testing.T) {
 
 	t.Run("ReportsEntrypointSpecificValidationErrors", func(t *testing.T) {
 		pipeline := buildkite.Pipeline{
-			Notify: &buildkite.BuildNotify{
+			Steps: &buildkite.PipelineSteps{
 				{
-					NotifyEmail: &buildkite.NotifyEmail{
-						Email: buildkite.Value("alerts@example.com"),
-						If:    buildkite.Value(`step.outcome == "failed"`),
+					CommandStep: &buildkite.CommandStep{
+						If: buildkite.Value(`step.label == "Deploy"`),
+					},
+				},
+				{
+					GroupStep: &buildkite.GroupStep{
+						Notify: &buildkite.BuildNotify{
+							{
+								NotifyEmail: &buildkite.NotifyEmail{
+									Email: buildkite.Value("alerts@example.com"),
+									If:    buildkite.Value(`step.outcome == "failed"`),
+								},
+							},
+						},
 					},
 				},
 			},
+		}
+
+		err := buildkite.ValidateConditionals(pipeline)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `steps[0].if: validation: step variables are not available for entry point "build_condition"`)
+		assert.ErrorContains(t, err, "steps[1].notify[0].if: validation: \"failed\" is not a valid `step.outcome`")
+	})
+
+	t.Run("MatchesSerializedStepArmOrder", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{
 			Steps: &buildkite.PipelineSteps{
 				{
-					NestedCommandStep: &buildkite.NestedCommandStep{
-						Command: &buildkite.CommandStep{
+					CommandStep: &buildkite.CommandStep{
+						If: buildkite.Value(`build.branch == "main"`),
+					},
+					NestedBlockStep: &buildkite.NestedBlockStep{
+						Block: &buildkite.BlockStep{
 							If: buildkite.Value(`build.branch == `),
 						},
 					},
@@ -116,7 +147,28 @@ func TestValidateConditionals(t *testing.T) {
 
 		err := buildkite.ValidateConditionals(pipeline)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, `notify[0].if: validation: step variables are not available for entry point "build_notification"`)
-		assert.ErrorContains(t, err, `steps[0].command.if: parse: no prefix parse function for EOF found`)
+		assert.ErrorContains(t, err, `steps[0].block.if: parse: no prefix parse function for EOF found`)
+		assert.NotContains(t, err.Error(), `steps[0].if`)
+	})
+
+	t.Run("MatchesSerializedNotificationArmOrder", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{
+			Notify: &buildkite.BuildNotify{
+				{
+					NotifyBasecamp: &buildkite.NotifyBasecamp{
+						BasecampCampfire: buildkite.Value("general"),
+						If:               buildkite.Value(`build.branch == "main"`),
+					},
+					NotifyEmail: &buildkite.NotifyEmail{
+						Email: buildkite.Value("alerts@example.com"),
+						If:    buildkite.Value(`build.branch == `),
+					},
+				},
+			},
+		}
+
+		err := buildkite.ValidateConditionals(pipeline)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `notify[0].if: parse: no prefix parse function for EOF found`)
 	})
 }

--- a/sdk/go/sdk_test/conditionals_test.go
+++ b/sdk/go/sdk_test/conditionals_test.go
@@ -1,0 +1,122 @@
+package sdk_test
+
+import (
+	"testing"
+
+	buildkite "github.com/buildkite/buildkite-sdk/sdk/go/sdk/buildkite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		condition, err := buildkite.Condition(`step.outcome == "passed"`)
+		require.NoError(t, err)
+		require.NotNil(t, condition)
+		assert.Equal(t, `step.outcome == "passed"`, *condition)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		condition, err := buildkite.Condition(`build.branch == `)
+		require.Error(t, err)
+		assert.Nil(t, condition)
+		assert.ErrorContains(t, err, "no prefix parse function for EOF found")
+	})
+}
+
+func TestMustCondition(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		condition := buildkite.MustCondition(`build.branch == "main"`)
+		require.NotNil(t, condition)
+		assert.Equal(t, `build.branch == "main"`, *condition)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		assert.Panics(t, func() {
+			buildkite.MustCondition(`build.branch == `)
+		})
+	})
+}
+
+func TestValidateConditionals(t *testing.T) {
+	t.Run("ValidatesStepAndNotificationConditionals", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{
+			Notify: &buildkite.BuildNotify{
+				{
+					NotifyEmail: &buildkite.NotifyEmail{
+						Email: buildkite.Value("alerts@example.com"),
+						If:    buildkite.Value(`build.branch == "main"`),
+					},
+				},
+			},
+			Steps: &buildkite.PipelineSteps{
+				{
+					CommandStep: &buildkite.CommandStep{
+						If: buildkite.MustCondition(`step.outcome == "passed"`),
+						Notify: &buildkite.CommandStepNotify{
+							{
+								NotifySlack: &buildkite.NotifySlack{
+									If: buildkite.Value(`step.outcome == "soft_failed"`),
+									Slack: &buildkite.NotifySlackSlack{
+										String: buildkite.Value("#builds"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					GroupStep: &buildkite.GroupStep{
+						If: buildkite.MustCondition(`build.branch == "main"`),
+						Notify: &buildkite.BuildNotify{
+							{
+								NotifyWebhook: &buildkite.NotifyWebhook{
+									If:      buildkite.Value(`step.outcome == "hard_failed"`),
+									Webhook: buildkite.Value("https://example.com/builds"),
+								},
+							},
+						},
+						Steps: &buildkite.GroupSteps{
+							{
+								NestedTriggerStep: &buildkite.NestedTriggerStep{
+									Trigger: &buildkite.TriggerStep{
+										If: buildkite.MustCondition(`step.label == "Deploy"`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, buildkite.ValidateConditionals(pipeline))
+	})
+
+	t.Run("ReportsEntrypointSpecificValidationErrors", func(t *testing.T) {
+		pipeline := buildkite.Pipeline{
+			Notify: &buildkite.BuildNotify{
+				{
+					NotifyEmail: &buildkite.NotifyEmail{
+						Email: buildkite.Value("alerts@example.com"),
+						If:    buildkite.Value(`step.outcome == "failed"`),
+					},
+				},
+			},
+			Steps: &buildkite.PipelineSteps{
+				{
+					NestedCommandStep: &buildkite.NestedCommandStep{
+						Command: &buildkite.CommandStep{
+							If: buildkite.Value(`build.branch == `),
+						},
+					},
+				},
+			},
+		}
+
+		err := buildkite.ValidateConditionals(pipeline)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `notify[0].if: validation: step variables are not available for entry point "build_notification"`)
+		assert.ErrorContains(t, err, `steps[0].command.if: parse: no prefix parse function for EOF found`)
+	})
+}


### PR DESCRIPTION
Go SDK users can set raw `if` strings today, but the SDK does not help them catch invalid or entrypoint-mismatched Buildkite conditionals before they serialize a dynamic pipeline and upload it.

This adds a small handwritten integration with `github.com/buildkite/conditional` in the Go SDK while keeping the generated schema and output format unchanged. Go callers can now validate a conditional when assigning an `if` field with `buildkite.Condition(...)` or `buildkite.MustCondition(...)`, and they can validate every reachable step and notification conditional in a generated pipeline with `buildkite.ValidateConditionals(pipeline)` before serialization.

The change is intentionally opt-in. `ToJSON()` and `ToYAML()` still behave the same way as before, so existing callers keep their current serialization flow unless they choose to add validation.

The README now shows the intended Go usage, including assigning a validated condition and running pipeline-wide validation before upload.

Checked with `go test ./...` and `go vet ./...` in `sdk/go`. The repo's `npx nx test sdk-go` wrapper could not run in this worktree because `node_modules` are not installed.