### PR TITLE
ci: Automerge low-risk Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,37 @@
   },
   "packageRules": [
     {
+      "description": "Automerge low-risk development tooling updates after CI passes",
+      "matchPackageNames": [
+        "@eslint/**",
+        "@types/**",
+        "autopep8",
+        "coverlet.collector",
+        "eslint",
+        "eslint-config-prettier",
+        "jest",
+        "jest-environment-node",
+        "jest-util",
+        "Microsoft.NET.Test.Sdk",
+        "pdoc",
+        "prettier",
+        "pytest",
+        "pytest-*",
+        "rubocop",
+        "rubocop-rake",
+        "rubocop-rspec",
+        "ruff",
+        "ts-jest",
+        "typedoc",
+        "typescript-eslint",
+        "xunit",
+        "xunit.*",
+        "yard"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
       "description": "Group Nx monorepo packages",
       "matchPackageNames": ["nx", "@nx/**", "@nrwl/**"],
       "groupName": "nx monorepo"


### PR DESCRIPTION
Renovate currently leaves green, low-risk tooling updates waiting for a manual approving review. That adds queue noise for changes like type-definition, linting, testing, and documentation-tool patches that are already covered by the Buildkite pipeline.

This adds a Renovate package rule that marks non-major low-risk development tooling updates for automerge after CI passes. The rule covers minor, patch, pin, and digest updates for linting/formatting tools, test frameworks, TypeScript type definitions, and documentation generators.

Major updates, Pulumi infrastructure packages, runtime SDK dependencies, language/toolchain versions, and Nx updates are intentionally left out so they still get human review.

On GitHub, actual auto-approval still depends on a Renovate approval helper app or ruleset bypass. This config marks the safe PRs as automerge candidates so that platform-side approval path can approve and merge them once checks pass.