### PR TITLE
Use precompiled Ruby in tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build from ruby:latest, as it's Debian-based, and keeps us from having to build Ruby from source.
+# Build from ruby:latest, as it's Debian-based.
 FROM ruby:latest AS base
 
 RUN apt-get update && apt-get install -y \
@@ -15,6 +15,8 @@ ENV MISE_CONFIG_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 ENV PATH="/mise/shims:$PATH"
+# mise compiles Ruby from source by default; install precompiled binaries instead (for ruby@3.4 below).
+ENV MISE_RUBY_COMPILE="0"
 RUN curl https://mise.run | sh
 
 # Install Node.js, Python, and Go.


### PR DESCRIPTION
## Summary

The `:lab_coat: Apps` Ruby step can hang until the job timeout. In build 1124 the [ruby-apps job](https://buildkite.com/buildkite/buildkite-sdk/builds/1124/list?jid=019f38eb-b169-4764-91b8-a920cf216c87&tab=output) sat for ~60 minutes until `BUILDKITE_TIMEOUT=60` cancelled the job. The step runs `mise install ruby@3.4`, which compiles Ruby from source via ruby-build. The hosted agent running the job got stuck at `./configure` and never reached `make`.

This change sets `MISE_RUBY_COMPILE=0` so mise installs a precompiled Ruby binary instead of building from source.

## Root cause

mise compiles Ruby from source by default. The `ruby:latest` base image does not prevent this (mise installs its own Ruby regardless), so the old comment claiming the base image avoided source builds was inaccurate. Source builds are slow and, on that agent, produced no output for the full hour before timing out.

## Fix

- Add `ENV MISE_RUBY_COMPILE="0"` so both the build-time layer and the in-container `mise install ruby@3.4` use precompiled binaries.
- Correct the now-inaccurate Dockerfile comments.

## Validation

- Reproduced the exact operation in the `ruby:latest` base: the source compile finished in ~93s with no interactive prompt and no error, so the command itself is fine and the CI stall was environmental. With `MISE_RUBY_COMPILE=0`, mise downloads a prebuilt binary in ~6s.
- Confirmed node, python, go, and dotnet already install prebuilt binaries via mise, so Ruby was the only toolchain compiling from source. No change needed for the others.
- `docker build --check` passes with no warnings.

## Notes

Takes effect once `buildkite-sdk-tools:latest` is rebuilt.
